### PR TITLE
fix: Resolve NameError for scientific constants in GUI

### DIFF
--- a/HesapMakinesi/gui_calculator.py
+++ b/HesapMakinesi/gui_calculator.py
@@ -3,6 +3,11 @@ from tkinter import messagebox
 import math # For math.pi and potentially other functions if not in calc_logic
 import calculator as calc_logic # Core calculator functions
 
+# Define physical constants at the module level BEFORE the class definition
+SPEED_OF_LIGHT = 299792458  # m/s
+PLANCK_CONSTANT = 6.62607015e-34  # J*s
+GRAVITATIONAL_CONSTANT = 6.67430e-11  # N*m^2/kg^2
+
 class CalculatorGUI:
     def __init__(self, master):
         self.master = master


### PR DESCRIPTION
I corrected a NameError in `HesapMakinesi/gui_calculator.py` that occurred because module-level scientific constants (SPEED_OF_LIGHT, PLANCK_CONSTANT, GRAVITATIONAL_CONSTANT) were defined after the `CalculatorGUI` class, but were accessed in its `__init__` method.

I moved the definitions of these constants to appear before the `CalculatorGUI` class definition, ensuring they are in the global scope when the class is defined and instantiated.