### PR TITLE
Fix constant name reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ GUI, üstte bir ekran alanı ve ardından çeşitli işlemler için düğme sır
         -   `c`: Vakumdaki ışık hızını ekler (yaklaşık 2.998e8 m/s).
         -   `h`: Planck sabitini ekler (yaklaşık 6.626e-34 J*s).
         -   `G`: Kütleçekim sabitini ekler (yaklaşık 6.674e-11 N*m²/kg²).
-    *Bir sabit düğmesine basmak, sembolünü (örneğin, "pi", "e", "c_isik") ifadeye ekler ve bu daha sonra tanımlanmış değeri kullanılarak değerlendirilir.*
+    *Bir sabit düğmesine basmak, sembolünü (örneğin, "pi", "e", "c_light") ifadeye ekler ve bu daha sonra tanımlanmış değeri kullanılarak değerlendirilir.*
 
 -   **Eşittir Düğmesi (`=`):** Görüntülenen mevcut ifadeyi değerlendirir.
 


### PR DESCRIPTION
## Summary
- fix README to reference `c_light` instead of placeholder `c_isik`

## Testing
- `python -m unittest test_calculator.py`

------
https://chatgpt.com/codex/tasks/task_e_683f710cf8848330bfd49dd9f9ae9694