### PR TITLE
Remove CLI reference from calculator module

### DIFF
--- a/HesapMakinesi/calculator.py
+++ b/HesapMakinesi/calculator.py
@@ -1,5 +1,5 @@
 # This is the calculator.py file.
-# It contains core calculator logic and a command-line interface.
+# It contains the core calculator logic.
 
 # --- Core Calculator Logic ---
 # The functions in this section are self-contained, perform mathematical


### PR DESCRIPTION
## Summary
- clarify top-of-file description in `calculator.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f73f7aff083308a55bacfc8e51d71